### PR TITLE
fix: Add timestamp to logging #16

### DIFF
--- a/nexus_exporter.py
+++ b/nexus_exporter.py
@@ -13,7 +13,7 @@ from prometheus_client.core import GaugeMetricFamily, REGISTRY
 import argparse
 
 LOG = logging.getLogger('nexus-exporter')
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(format='%(asctime)s %(message)s',level=logging.INFO)
 
 
 def valid_url(string):


### PR DESCRIPTION
This should give the time context to the log messages that are printed. Helps in triaging when the service is up but exporter is not able to talk to the Prometheus server.